### PR TITLE
Fix screen interactions for 1.16 client

### DIFF
--- a/src/main/java/com/slayvisual/SlayvisualClient.java
+++ b/src/main/java/com/slayvisual/SlayvisualClient.java
@@ -47,9 +47,9 @@ public class SlayvisualClient implements ClientModInitializer {
 
                 Screen current = client.currentScreen;
                 if (current instanceof SlayvisualScreen) {
-                        client.setScreen(null);
+                        client.openScreen(null);
                 } else {
-                        client.setScreen(new SlayvisualScreen());
+                        client.openScreen(new SlayvisualScreen());
                 }
         }
 }


### PR DESCRIPTION
## Summary
- replace the screen toggle logic with the 1.16-compatible `openScreen` calls
- rework GUI widget management to rely on `addButton`/list clearing and adjust rendering helpers for the older API
- correct the combat interval slider setter casting so it compiles on Java 8

## Testing
- `./gradlew build` *(fails: Gradle wrapper download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d917e36d6483328e20544c5ad2d9e9